### PR TITLE
added helper methods to get and directly set trauma

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,17 @@ impl Shake {
     pub fn add_trauma(&mut self, amount: f32) {
         self.trauma = (self.trauma + amount).clamp(0., 1.);
     }
+
+    /// Sets the trauma to a specified value. Trauma is clamped between 0 and 1, and decays
+    /// over time according to [`ShakeSettings::decay_per_second`].
+    pub fn set_trauma(&mut self, amount: f32) {
+        self.trauma = amount.clamp(0., 1.);
+    }
+
+    /// Gets the current trauma.
+    pub fn trauma(&self) -> f32 {
+        self.trauma
+    }
 }
 
 fn shake(mut shakes: Query<(&mut Shake, &mut Transform, Option<&ShakeSettings>)>, time: Res<Time>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ impl Shake {
         self.trauma = amount.clamp(0., 1.);
     }
 
-    /// Gets the current trauma.
+    /// Gets the current trauma
     pub fn trauma(&self) -> f32 {
         self.trauma
     }

--- a/src/system_param.rs
+++ b/src/system_param.rs
@@ -21,4 +21,11 @@ impl Shakes<'_, '_> {
             shake.add_trauma(trauma);
         }
     }
+
+    /// Sets the trauma to a specified value for all [`Shake`]s
+    pub fn set_trauma(&mut self, trauma: f32) {
+        for mut shake in &mut self.0 {
+            shake.set_trauma(trauma);
+        }
+    }
 }


### PR DESCRIPTION
In many cases, additive trauma is not desirable. This adds two methods to `Shake` that allow for user-defined control: 

- `set_trauma`: directly sets the trauma value
- `trauma`: gets the current trauma value

This also adds the `set_trauma` to the `Shakes` convenience params.

This solves #8 as well